### PR TITLE
SQLite query null

### DIFF
--- a/bug-report.test.ts
+++ b/bug-report.test.ts
@@ -82,6 +82,18 @@ describe("bug-report.test.ts", () => {
         schema: mySchema,
       },
     });
+    await collections.mycollection.insert({
+      id: "a",
+      expiresAt: null,
+    });
+    await collections.mycollection.insert({
+      id: "b",
+      expiresAt: new Date(Date.now() + 100_000).toISOString(),
+    });
+    await collections.mycollection.insert({
+      id: "c",
+      expiresAt: new Date(Date.now() - 100_000).toISOString(),
+    });
 
     const found = await collections.mycollection
       .find({
@@ -91,9 +103,13 @@ describe("bug-report.test.ts", () => {
             { expiresAt: null },
           ],
         },
+        sort: [{ id: "asc" }],
       })
       .exec();
 
     assert.ok(Array.isArray(found));
+    assert.ok(found.length === 2);
+    assert.ok(found[0].id === "a");
+    assert.ok(found[1].id === "b");
   });
 });

--- a/bug-report.test.ts
+++ b/bug-report.test.ts
@@ -8,146 +8,92 @@
  * - 'npm run test:node' so it runs in nodejs
  * - 'npm run test:browser' so it runs in the browser
  */
-import assert from 'assert';
-import AsyncTestUtil from 'async-test-util';
+import assert from "assert";
+import AsyncTestUtil from "async-test-util";
 
-import {
-    createRxDatabase,
-    randomToken,
-    addRxPlugin
-} from 'rxdb/plugins/core';
+import { createRxDatabase, randomToken, addRxPlugin } from "rxdb/plugins/core";
 
-import { RxDBDevModePlugin } from 'rxdb/plugins/dev-mode';
-import { wrappedValidateAjvStorage } from 'rxdb/plugins/validate-ajv';
-import { RxDBQueryBuilderPlugin } from 'rxdb/plugins/query-builder';
+import { RxDBDevModePlugin } from "rxdb/plugins/dev-mode";
+import { wrappedValidateAjvStorage } from "rxdb/plugins/validate-ajv";
+import { RxDBQueryBuilderPlugin } from "rxdb/plugins/query-builder";
 
-import {
-    isNode
-} from 'rxdb/plugins/test-utils';
-
+import { isNode } from "rxdb/plugins/test-utils";
 
 /**
  * You can import any RxDB Premium Plugins here
-*/
-import { getRxStorageIndexedDB } from 'rxdb-premium/plugins/storage-indexeddb';
-import { getRxStorageSQLite, getSQLiteBasicsNodeNative } from 'rxdb-premium/plugins/storage-sqlite';
+ */
+import { getRxStorageIndexedDB } from "rxdb-premium/plugins/storage-indexeddb";
+import {
+  getRxStorageSQLite,
+  getSQLiteBasicsNodeNative,
+} from "rxdb-premium/plugins/storage-sqlite";
 
-describe('bug-report.test.ts', () => {
+describe("bug-report.test.ts", () => {
+  addRxPlugin(RxDBDevModePlugin);
+  addRxPlugin(RxDBQueryBuilderPlugin);
 
-    addRxPlugin(RxDBDevModePlugin);
-    addRxPlugin(RxDBQueryBuilderPlugin);
-
-    it('should fail because it reproduces the bug', async function () {
-
-
-        let storage: any;
-        if (isNode) {
-            const { DatabaseSync } = require('node:sqlite' + '');
-            storage = getRxStorageSQLite({
-                sqliteBasics: getSQLiteBasicsNodeNative(DatabaseSync)
-            });
-        } else {
-            storage = getRxStorageIndexedDB();
-        }
-        storage = wrappedValidateAjvStorage({
-            storage
-        });
-
-        // create a schema
-        const mySchema = {
-            version: 0,
-            primaryKey: 'passportId',
-            type: 'object',
-            properties: {
-                passportId: {
-                    type: 'string',
-                    maxLength: 100
-                },
-                firstName: {
-                    type: 'string'
-                },
-                lastName: {
-                    type: 'string'
-                },
-                age: {
-                    type: 'integer',
-                    minimum: 0,
-                    maximum: 150
-                }
-            }
-        };
-
-        /**
-         * Always generate a random database-name
-         * to ensure that different test runs do not affect each other.
-         */
-        const name = randomToken(10);
-
-        // create a database
-        const db = await createRxDatabase({
-            name,
-            storage: storage,
-            eventReduce: true,
-            ignoreDuplicate: true
-        });
-        // create a collection
-        const collections = await db.addCollections({
-            mycollection: {
-                schema: mySchema
-            }
-        });
-
-        // insert a document
-        await collections.mycollection.insert({
-            passportId: 'foobar',
-            firstName: 'Bob',
-            lastName: 'Kelso',
-            age: 56
-        });
-
-        /**
-         * to simulate the event-propagation over multiple browser-tabs,
-         * we create the same database again
-         */
-        const dbInOtherTab = await createRxDatabase({
-            name,
-            storage,
-            eventReduce: true,
-            ignoreDuplicate: true
-        });
-        // create a collection
-        const collectionInOtherTab = await dbInOtherTab.addCollections({
-            mycollection: {
-                schema: mySchema
-            }
-        });
-
-        // find the document in the other tab
-        const myDocument = await collectionInOtherTab.mycollection
-            .findOne()
-            .where('firstName')
-            .eq('Bob')
-            .exec();
-
-        /*
-         * assert things,
-         * here your tests should fail to show that there is a bug
-         */
-        assert.strictEqual(myDocument.age, 56);
-
-
-        // you can also wait for events
-        const emitted: any[] = [];
-        const sub = collectionInOtherTab.mycollection
-            .findOne().$
-            .subscribe(doc => {
-                emitted.push(doc);
-            });
-        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
-
-        // clean up afterwards
-        sub.unsubscribe();
-        db.close();
-        dbInOtherTab.close();
+  it("sqlite storage fails querying", async function () {
+    let storage: any;
+    if (isNode) {
+      const { DatabaseSync } = require("node:sqlite" + "");
+      storage = getRxStorageSQLite({
+        sqliteBasics: getSQLiteBasicsNodeNative(DatabaseSync),
+      });
+    } else {
+      storage = getRxStorageIndexedDB();
+    }
+    storage = wrappedValidateAjvStorage({
+      storage,
     });
+
+    // create a schema
+    const mySchema = {
+      version: 0,
+      primaryKey: "id",
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          maxLength: 100,
+        },
+        expiresAt: {
+          type: ["string", "null"],
+          format: "date-time",
+        },
+      },
+    };
+
+    /**
+     * Always generate a random database-name
+     * to ensure that different test runs do not affect each other.
+     */
+    const name = randomToken(10);
+
+    // create a database
+    const db = await createRxDatabase({
+      name,
+      storage: storage,
+      eventReduce: true,
+      ignoreDuplicate: true,
+    });
+    // create a collection
+    const collections = await db.addCollections({
+      mycollection: {
+        schema: mySchema,
+      },
+    });
+
+    const found = await collections.mycollection
+      .find({
+        selector: {
+          $or: [
+            { expiresAt: { $gt: new Date().toISOString() } },
+            { expiresAt: null },
+          ],
+        },
+      })
+      .exec();
+
+    assert.ok(Array.isArray(found));
+  });
 });


### PR DESCRIPTION
Good day :)

It appears that if something is queried in the SQLite storage with `null` the query is not executed / translated correctly into a SQLite query.

In the testcase I have a schema with the fields `id` and `expiresAt`. `expiresAt` can either be a `Date` string or `null`.
I'm then adding 3 entities to the collection:
1. With `expiresAt: null`
2. With `expiresAt: FutureDate`
3. With `expiresAt: PastDate`

Then I'm querying the collection with:
```js
{
  selector: {
    $or: [
      { expiresAt: { $gt: new Date().toISOString() } },
      { expiresAt: null },
    ],
  }
}
```

Which should give me two entities as a result. The entity with `expiresAt: null` and the one with `expiresAt: FutureDate`.
The result I'm getting is just the one with `expiresAt: FutureDate`.