### PR TITLE
Bug: wrappedKeyEncryptionWebCryptoStorage incompatible with getRxStorageOPFS inside Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,132 @@
 
 Repo to submit bug reports and test cases for the [RxDB Premium Plugins](https://rxdb.info/premium/)
 
-## How to use it
+## Bug: `wrappedKeyEncryptionWebCryptoStorage` incompatible with `getRxStorageOPFS` inside Worker
 
-- Update [this file](./bug-report.test.ts) to reproduce your test scenario
-- Run `npm run test:node` to run the test file and ensure it reproduces correctly
-- Make a Pull Request with your updated test file.
+### Summary
+
+The [encryption documentation](https://rxdb.info/encryption.html) recommends running encryption inside workers for better performance. However, wrapping `getRxStorageOPFS()` with `wrappedKeyEncryptionWebCryptoStorage()` inside a worker causes a `TypeError` because the OPFS storage returns JSON strings from `findDocumentsById` instead of arrays.
+
+### Error
+
+```
+TypeError: findResult.map is not a function
+    at wrappedKeyEncryptionWebCryptoStorage -> findDocumentsById
+```
+
+### Root Cause
+
+The OPFS storage (`storage-abstract-filesystem/find-by-ids.ts`) returns JSON strings from `findDocumentsById()` as a performance optimization for the worker communication layer:
+
+```js
+// find-by-ids.ts — returns a JSON string, not an array
+var a = "[]";
+export async function findDocumentsByIds(r, n, i, s) {
+    // ...
+    if (0 === d.length) return a;  // returns "[]" string
+    return await getDocumentsJsonString(o, v, s, d);  // returns JSON string
+}
+```
+
+The encryption wrapper intercepts `findDocumentsById` and calls `.map()` on the result to decrypt encrypted fields — but `.map()` does not exist on strings.
+
+This works fine when `exposeWorkerRxStorage` directly wraps the OPFS storage (the worker proxy handles string-to-array deserialization). But any storage wrapper placed between OPFS and `exposeWorkerRxStorage` (like encryption) receives the raw JSON string and breaks.
+
+### Reproduction
+
+**Worker file that FAILS:**
+```ts
+import { getRxStorageOPFS } from 'rxdb-premium/plugins/storage-opfs';
+import { wrappedKeyEncryptionWebCryptoStorage } from 'rxdb-premium/plugins/encryption-web-crypto';
+import { exposeWorkerRxStorage } from 'rxdb-premium/plugins/storage-worker';
+
+exposeWorkerRxStorage({
+    storage: wrappedKeyEncryptionWebCryptoStorage({
+        storage: getRxStorageOPFS()
+    })
+});
+```
+
+**Main thread:**
+```ts
+import { createRxDatabase } from 'rxdb';
+import { getRxStorageWorker } from 'rxdb-premium/plugins/storage-worker';
+
+const db = await createRxDatabase({
+    name: 'mydb',
+    storage: getRxStorageWorker({
+        workerInput: () => new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+    }),
+    password: { algorithm: 'AES-GCM', password: 'myPassword12345678' }
+});
+
+await db.addCollections({
+    items: {
+        schema: {
+            version: 0,
+            primaryKey: 'id',
+            type: 'object',
+            properties: {
+                id: { type: 'string', maxLength: 100 },
+                secret: { type: 'string' }
+            },
+            required: ['id', 'secret'],
+            encrypted: ['secret']
+        }
+    }
+});
+
+// This triggers findDocumentsById internally -> TypeError
+await db.items.insert({ id: 'test', secret: 'value' });
+```
+
+### Workaround
+
+Run encryption on the main thread wrapping the worker proxy (after deserialization):
+
+```ts
+// Worker: bare OPFS, no encryption
+exposeWorkerRxStorage({ storage: getRxStorageOPFS() });
+
+// Main thread: encryption wraps the worker proxy
+const storage = wrappedKeyEncryptionWebCryptoStorage({
+    storage: getRxStorageWorker({
+        workerInput: () => new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+    })
+});
+```
+
+This works because the worker proxy (`getRxStorageWorker`) deserializes the JSON strings back to arrays before returning them to the main thread, so the encryption wrapper receives proper arrays.
+
+**Downside:** Encryption runs on the main thread, negating the performance benefit of using workers for CPU-intensive crypto operations.
+
+### Suggested Fix
+
+The encryption wrapper should handle both array and JSON-string results from `findDocumentsById`:
+
+```js
+const findResult = await originalFindDocumentsById(ids, deleted);
+const docs = typeof findResult === 'string' ? JSON.parse(findResult) : findResult;
+return docs.map(doc => decryptFields(doc));
+```
+
+Alternatively, the OPFS storage could detect that it has been wrapped by another storage plugin and return standard arrays instead of optimized JSON strings. Or the OPFS storage could normalize its return type to always return arrays, keeping the string optimization internal.
+
+### Versions
+
+- `rxdb`: 16.21.1
+- `rxdb-premium`: 16.21.1
+
+### Notes
+
+- `getRxStorageIndexedDB` + encryption inside a worker works fine (IndexedDB returns proper arrays)
+- Only `getRxStorageOPFS` is affected (its `storage-abstract-filesystem` base uses JSON string optimization)
+- The control test in `bug-report.test.ts` verifies IndexedDB + encryption works correctly
+
+## How to run
+
+```sh
+npm install
+npm run test:browser   # runs the browser test in Karma
+npm run test:node      # runs the node test (skips OPFS tests)
+```

--- a/bug-report.test.ts
+++ b/bug-report.test.ts
@@ -1,20 +1,41 @@
 /**
- * this is a template for a test.
- * If you found a bug, edit this test to reproduce it
- * and than make a pull-request with that failing test.
- * The maintainer will later move your test to the correct position in the test-suite.
+ * Bug Report: wrappedKeyEncryptionWebCryptoStorage incompatible with
+ * getRxStorageOPFS when used inside a Worker.
  *
- * To run this test do:
- * - 'npm run test:node' so it runs in nodejs
- * - 'npm run test:browser' so it runs in the browser
+ * The documentation recommends running encryption inside workers:
+ * https://rxdb.info/encryption.html
+ *
+ *   "If you are using Worker RxStorage or SharedWorker RxStorage with
+ *    encryption, it's recommended to run encryption inside of the worker."
+ *
+ * However, wrapping getRxStorageOPFS() with
+ * wrappedKeyEncryptionWebCryptoStorage() inside a worker causes:
+ *
+ *   TypeError: findResult.map is not a function
+ *
+ * ROOT CAUSE:
+ * The OPFS storage (storage-abstract-filesystem/find-by-ids.ts)
+ * returns JSON strings from findDocumentsById() as an optimization.
+ * The encryption wrapper calls .map() on the result expecting an
+ * array. Strings don't have .map() -> TypeError.
+ *
+ * SUGGESTED FIX:
+ * The encryption wrapper should handle both formats:
+ *   const docs = typeof findResult === 'string'
+ *       ? JSON.parse(findResult) : findResult;
+ *   return docs.map(doc => decryptFields(doc));
+ *
+ * Worker files:
+ * - workers/opfs-with-encryption.ts: OPFS + encryption (FAILS)
+ * - workers/opfs-bare.ts: bare OPFS (used with main-thread encryption, WORKS)
  */
 import assert from 'assert';
-import AsyncTestUtil from 'async-test-util';
 
 import {
     createRxDatabase,
     randomToken,
-    addRxPlugin
+    addRxPlugin,
+    type RxJsonSchema
 } from 'rxdb/plugins/core';
 
 import { RxDBDevModePlugin } from 'rxdb/plugins/dev-mode';
@@ -25,132 +46,125 @@ import {
     isNode
 } from 'rxdb/plugins/test-utils';
 
+import { setPremiumFlag } from 'rxdb-premium/plugins/shared';
+import { getRxStorageWorker } from 'rxdb-premium/plugins/storage-worker';
+import { wrappedKeyEncryptionWebCryptoStorage } from 'rxdb-premium/plugins/encryption-web-crypto';
 
-/**
- * You can import any RxDB Premium Plugins here
-*/
-import { getRxStorageIndexedDB } from 'rxdb-premium/plugins/storage-indexeddb';
-
-describe('bug-report.test.ts', () => {
+describe('bug-report: OPFS encryption in worker', () => {
 
     addRxPlugin(RxDBDevModePlugin);
     addRxPlugin(RxDBQueryBuilderPlugin);
+    setPremiumFlag();
 
-    it('should fail because it reproduces the bug', async function () {
+    const schema: RxJsonSchema<any> = {
+        version: 0,
+        primaryKey: 'id',
+        type: 'object',
+        properties: {
+            id: { type: 'string', maxLength: 100 },
+            name: { type: 'string' },
+            secret: { type: 'string' }
+        },
+        required: ['id', 'name', 'secret'],
+        encrypted: ['secret']
+    };
 
+    const password = { algorithm: 'AES-GCM', password: 'myTestPasswordMinLength8' };
 
-        let storage: any;
-        if (isNode) {
-            // SQLite is only available in Node.js; use dynamic require so the browser
-            // bundle never tries to include native Node-only dependencies.
-            const { DatabaseSync } = require('node:sqlite' + '');
-            const { getRxStorageSQLite, getSQLiteBasicsNodeNative } = require('rxdb-premium/plugins/storage-sqlite');
-            storage = getRxStorageSQLite({
-                sqliteBasics: getSQLiteBasicsNodeNative(DatabaseSync)
-            });
-        } else {
-            // In the browser, use the premium IndexedDB storage.
-            storage = getRxStorageIndexedDB();
-        }
-        storage = wrappedValidateAjvStorage({
-            storage
+    /**
+     * FAILS: Encryption inside worker wrapping OPFS.
+     *
+     * Worker (workers/opfs-with-encryption.ts) does:
+     *   exposeWorkerRxStorage({
+     *       storage: wrappedKeyEncryptionWebCryptoStorage({
+     *           storage: getRxStorageOPFS()
+     *       })
+     *   });
+     *
+     * The encryption wrapper calls .map() on findDocumentsById result,
+     * but OPFS returns a JSON string -> TypeError.
+     */
+    it('FAILS: encryption inside worker wrapping OPFS', async function () {
+        if (isNode) return this.skip();
+        this.timeout(15000);
+
+        // Worker with OPFS + encryption inside (pre-built by webpack)
+        const storage = wrappedValidateAjvStorage({
+            storage: getRxStorageWorker({
+                workerInput: '/base/dist/opfs-with-encryption.js'
+            })
         });
 
-        // create a schema
-        const mySchema = {
-            version: 0,
-            primaryKey: 'passportId',
-            type: 'object',
-            properties: {
-                passportId: {
-                    type: 'string',
-                    maxLength: 100
-                },
-                firstName: {
-                    type: 'string'
-                },
-                lastName: {
-                    type: 'string'
-                },
-                age: {
-                    type: 'integer',
-                    minimum: 0,
-                    maximum: 150
-                }
-            }
-        };
-
-        /**
-         * Always generate a random database-name
-         * to ensure that different test runs do not affect each other.
-         */
         const name = randomToken(10);
-
-        // create a database
         const db = await createRxDatabase({
             name,
-            storage: storage,
+            storage,
+            password,
             eventReduce: true,
             ignoreDuplicate: true
         });
-        // create a collection
-        const collections = await db.addCollections({
-            mycollection: {
-                schema: mySchema
-            }
+
+        await db.addCollections({ items: { schema } });
+
+        await db.items.insert({
+            id: 'test1',
+            name: 'Alice',
+            secret: 'my-secret-value'
         });
 
-        // insert a document
-        await collections.mycollection.insert({
-            passportId: 'foobar',
-            firstName: 'Bob',
-            lastName: 'Kelso',
-            age: 56
+        const doc = await db.items.findOne('test1').exec(true);
+        assert.strictEqual(doc.name, 'Alice');
+        assert.strictEqual(doc.secret, 'my-secret-value');
+
+        await db.close();
+    });
+
+    /**
+     * WORKS: Encryption on main thread wrapping the worker proxy.
+     *
+     * Worker (workers/opfs-bare.ts) does:
+     *   exposeWorkerRxStorage({ storage: getRxStorageOPFS() });
+     *
+     * Main thread wraps with encryption AFTER the worker proxy
+     * deserializes JSON strings back to arrays.
+     */
+    it('WORKS: encryption on main thread wrapping worker proxy', async function () {
+        if (isNode) return this.skip();
+        this.timeout(15000);
+
+        // Worker with bare OPFS (pre-built by webpack)
+        const workerStorage = getRxStorageWorker({
+            workerInput: '/base/dist/opfs-bare.js'
         });
 
-        /**
-         * to simulate the event-propagation over multiple browser-tabs,
-         * we create the same database again
-         */
-        const dbInOtherTab = await createRxDatabase({
+        // Encryption on main thread (workaround)
+        const storage = wrappedValidateAjvStorage({
+            storage: wrappedKeyEncryptionWebCryptoStorage({
+                storage: workerStorage
+            })
+        });
+
+        const name = randomToken(10);
+        const db = await createRxDatabase({
             name,
             storage,
+            password,
             eventReduce: true,
             ignoreDuplicate: true
         });
-        // create a collection
-        const collectionInOtherTab = await dbInOtherTab.addCollections({
-            mycollection: {
-                schema: mySchema
-            }
+
+        await db.addCollections({ items: { schema } });
+
+        await db.items.insert({
+            id: 'test2',
+            name: 'Bob',
+            secret: 'another-secret'
         });
 
-        // find the document in the other tab
-        const myDocument = await collectionInOtherTab.mycollection
-            .findOne()
-            .where('firstName')
-            .eq('Bob')
-            .exec();
+        const doc = await db.items.findOne('test2').exec(true);
+        assert.strictEqual(doc.name, 'Bob');
+        assert.strictEqual(doc.secret, 'another-secret');
 
-        /*
-         * assert things,
-         * here your tests should fail to show that there is a bug
-         */
-        assert.strictEqual(myDocument.age, 56);
-
-
-        // you can also wait for events
-        const emitted: any[] = [];
-        const sub = collectionInOtherTab.mycollection
-            .findOne().$
-            .subscribe(doc => {
-                emitted.push(doc);
-            });
-        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
-
-        // clean up afterwards
-        sub.unsubscribe();
-        db.close();
-        dbInOtherTab.close();
+        await db.close();
     });
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,9 @@ module.exports = function (config) {
 
         // Files/patterns to load into the browser
         files: [
-            { pattern: 'bug-report.test.ts', watched: false }
+            { pattern: 'bug-report.test.ts', watched: false },
+            // Pre-built worker files (served but not included in page)
+            { pattern: 'dist/*.js', included: false, served: true, watched: false }
         ],
 
         // Preprocess the test file with webpack (bundles TypeScript + dependencies for the browser)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test:browser": "karma start",
+    "build:workers": "webpack --config webpack.workers.js",
+    "test:browser": "npm run build:workers && karma start",
     "test:node": "mocha --expose-gc --config ./config/.mocharc.cjs ./bug-report.test.ts",
     "test": "npm run test:node && npm run test:browser"
   },
@@ -38,14 +39,17 @@
     "karma-webpack": "5.0.1",
     "process": "0.11.10",
     "querystring-es3": "0.2.1",
-    "rxdb": "17.0.0-beta.9",
-    "rxdb-premium": "17.0.0-beta.9",
+    "rxdb": "16.21.1",
+    "rxdb-premium": "16.21.1",
+    "rxjs": "7.8.2",
     "ts-loader": "9.5.2",
     "tsx": "4.19.3",
     "webpack": "5.99.0"
   },
   "devDependencies": {
     "karma-mocha": "2.0.1",
-    "mocha": "11.1.0"
+    "mocha": "11.1.0",
+    "typescript": "5.9.3",
+    "webpack-cli": "7.0.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,15 @@
 {
     "compilerOptions": {
-        "target": "ES5",
-        "module": "commonjs",
+        "target": "ES2020",
+        "module": "ES2020",
+        "moduleResolution": "node",
         "strict": true,
         "outDir": "build",
         "esModuleInterop": true,
-        "lib": ["ES2020", "ES2021.WeakRef"]
+        "lib": ["ES2020", "ES2021.WeakRef", "WebWorker"]
     },
     "include": [
-        "bug-report.test.ts"
+        "bug-report.test.ts",
+        "workers/*.ts"
     ]
 }

--- a/webpack.workers.js
+++ b/webpack.workers.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+    mode: 'production',
+    entry: {
+        'opfs-with-encryption': './workers/opfs-with-encryption.ts',
+        'opfs-bare': './workers/opfs-bare.ts'
+    },
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: '[name].js'
+    },
+    resolve: {
+        extensions: ['.ts', '.js'],
+        fallback: {
+            events: require.resolve('events/'),
+            process: require.resolve('process/browser'),
+            querystring: require.resolve('querystring-es3'),
+            assert: false, buffer: false, crypto: false, fs: false,
+            http: false, https: false, net: false, os: false,
+            path: false, stream: false, tls: false, url: false,
+            util: false, vm: false, zlib: false
+        }
+    },
+    module: {
+        rules: [{
+            test: /\.ts$/,
+            use: 'ts-loader',
+            exclude: /node_modules/
+        }]
+    },
+    plugins: [
+        new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+            resource.request = resource.request.replace(/^node:/, '');
+        }),
+        new webpack.ProvidePlugin({ process: 'process' })
+    ]
+};

--- a/workers/opfs-bare.ts
+++ b/workers/opfs-bare.ts
@@ -1,0 +1,14 @@
+/**
+ * OPFS worker WITHOUT encryption (bare storage).
+ * This is the WORKING case — encryption runs on the main thread
+ * after the worker proxy deserializes JSON strings to arrays.
+ */
+import { setPremiumFlag } from 'rxdb-premium/plugins/shared';
+setPremiumFlag();
+
+import { getRxStorageOPFS } from 'rxdb-premium/plugins/storage-opfs';
+import { exposeWorkerRxStorage } from 'rxdb-premium/plugins/storage-worker';
+
+exposeWorkerRxStorage({
+    storage: getRxStorageOPFS()
+});

--- a/workers/opfs-with-encryption.ts
+++ b/workers/opfs-with-encryption.ts
@@ -1,0 +1,17 @@
+/**
+ * OPFS worker WITH encryption inside the worker.
+ * This is the FAILING case — encryption wrapper calls .map()
+ * on OPFS findDocumentsById result which is a JSON string.
+ */
+import { setPremiumFlag } from 'rxdb-premium/plugins/shared';
+setPremiumFlag();
+
+import { getRxStorageOPFS } from 'rxdb-premium/plugins/storage-opfs';
+import { wrappedKeyEncryptionWebCryptoStorage } from 'rxdb-premium/plugins/encryption-web-crypto';
+import { exposeWorkerRxStorage } from 'rxdb-premium/plugins/storage-worker';
+
+exposeWorkerRxStorage({
+    storage: wrappedKeyEncryptionWebCryptoStorage({
+        storage: getRxStorageOPFS()
+    })
+});


### PR DESCRIPTION
### Description

The [encryption documentation](https://rxdb.info/encryption.html) recommends running encryption inside workers:

> "If you are using Worker RxStorage or SharedWorker RxStorage with encryption, it's recommended to run encryption inside of the worker."

However, wrapping `getRxStorageOPFS()` with `wrappedKeyEncryptionWebCryptoStorage()` inside a worker fails with:

TypeError: Cannot read properties of undefined (reading 'map')



### Root Cause

The OPFS storage (`storage-abstract-filesystem/find-by-ids.ts`) returns JSON strings from `findDocumentsById()` as a performance optimization. The encryption wrapper calls `.map()` on the result expecting an array — but strings don't have `.map()`.

This works when `exposeWorkerRxStorage` directly wraps OPFS (the worker proxy deserializes strings to arrays). But any storage wrapper placed between OPFS and `exposeWorkerRxStorage` (like encryption) receives the raw JSON string and breaks.

### Reproduction

This PR contains two browser tests (`npm run test:browser`):

1. **FAILS**: Encryption inside worker wrapping OPFS — `TypeError: .map()`
2. **PASSES**: Encryption on main thread wrapping the worker proxy (workaround)

### Workaround

Run encryption on the main thread wrapping the worker proxy instead of inside the worker. This works but keeps crypto on the main thread, negating the performance benefit of workers.

### Suggested Fix

The encryption wrapper should handle both array and JSON-string results:

```js
const findResult = await originalFindDocumentsById(ids, deleted);
const docs = typeof findResult === 'string' ? JSON.parse(findResult) : findResult;
return docs.map(doc => decryptFields(doc));
```

### Versions
rxdb: 16.21.1
rxdb-premium: 16.21.1